### PR TITLE
dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@
 # Ignore Byebug command history file.
 .byebug_history
 
+# Ignore local config
 .env
-.rbenv-vars
-config/id_rsa*

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ end
 
 group :development, :test do
   gem 'byebug', platform: :mri
+  gem 'dotenv-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,10 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -160,6 +164,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   byebug
   connection_pool
+  dotenv-rails
   factory_girl_rails
   hiredis
   json-jwt


### PR DESCRIPTION
fixes #25 

Adds better errors when certain ENV variables are missing, and standardizes on `.env` so that Docker, RVM, and rbenv dev environments can have something in common.