### PR TITLE
SessionJWT

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,7 @@ class AccountsController < ApplicationController
       establish_session(account.id, requesting_audience)
 
       render status: :created, json: JSONEnvelope.result(
-        id_token: issue_token_from(session)
+        id_token: issue_token_from(authn_session)
       )
     else
       render status: :unprocessable_entity, json: JSONEnvelope.errors(creator.errors)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,11 +32,10 @@ class ApplicationController < ActionController::API
     cookies[AUTHN_SESSION_NAME] = {
       value: JSON::JWT.new(
         iss: Rails.application.config.authn_url,
-        sub: account_id,
+        sub: RefreshToken.create(account_id),
         aud: Rails.application.config.authn_url,
         iat: Time.now.utc.to_i,
-        azp: audience,
-        token: RefreshToken.create(account_id)
+        azp: audience
       ).sign(Rails.application.config.session_key, 'HS256').to_s,
       secure: Rails.application.config.force_ssl,
       httponly: true
@@ -54,7 +53,7 @@ class ApplicationController < ActionController::API
 
     JSON::JWT.new(
       iss: sess[:iss],
-      sub: sess[:sub],
+      sub: RefreshToken.find(sess[:sub]),
       aud: sess[:azp],
       exp: Time.now.utc.to_i + Rails.application.config.access_token_expiry,
       iat: Time.now.utc.to_i,

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -29,7 +29,7 @@ class PasswordsController < ApplicationController
       establish_session(updater.account.id, requesting_audience)
 
       render status: :created, json: JSONEnvelope.result(
-        id_token: issue_token_from(session)
+        id_token: issue_token_from(authn_session)
       )
     else
       render status: :unprocessable_entity, json: JSONEnvelope.errors(updater.errors)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -50,7 +50,7 @@ class SessionsController < ApplicationController
     raise AccessForbidden unless referred?
 
     RefreshToken.revoke(authn_session[:sub])
-    cookies.delete(AUTHN_SESSION_NAME)
+    cookies.delete(AuthNSession::NAME)
 
     redirect_host = begin
       URI.parse(params[:redirect_uri]).host

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,8 +34,8 @@ class SessionsController < ApplicationController
   def refresh
     raise AccessForbidden unless referred?
 
-    if authn_session[:sub] && RefreshToken.find(authn_session[:token])
-      RefreshToken.touch(token: authn_session[:token], account_id: session[:sub])
+    if account_id = RefreshToken.find(authn_session[:sub])
+      RefreshToken.touch(token: authn_session[:sub], account_id: account_id)
       render status: :created, json: JSONEnvelope.result(
         id_token: issue_token_from(authn_session)
       )
@@ -49,7 +49,7 @@ class SessionsController < ApplicationController
   def destroy
     raise AccessForbidden unless referred?
 
-    RefreshToken.revoke(authn_session[:token])
+    RefreshToken.revoke(authn_session[:sub])
     cookies.delete(AUTHN_SESSION_NAME)
 
     redirect_host = begin

--- a/app/models/refresh_token.rb
+++ b/app/models/refresh_token.rb
@@ -13,7 +13,7 @@ module RefreshToken
     bin = [hex].pack('H*')
 
     REDIS.with do |conn|
-      conn.get("s:t.#{bin}")
+      conn.get("s:t.#{bin}").try!(:to_i)
     end
   end
 

--- a/app/models/session_jwt.rb
+++ b/app/models/session_jwt.rb
@@ -1,0 +1,16 @@
+class SessionJWT
+  def self.generate(account_id, azp)
+    JSON::JWT.new(
+      iss: Rails.application.config.authn_url,
+      sub: RefreshToken.create(account_id),
+      aud: Rails.application.config.authn_url,
+      iat: Time.now.utc.to_i,
+      azp: azp
+    ).sign(Rails.application.config.session_key, 'HS256').to_s
+  end
+
+  def self.decode(str)
+    return {} if str.blank?
+    JSON::JWT.decode(str, Rails.application.config.session_key) || {}
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,5 @@ module AuthServer
     config.api_only = true
 
     config.middleware.insert_before Rack::Head, ActionDispatch::Cookies
-    config.middleware.insert_before Rack::Head, ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/app.rb
+++ b/config/initializers/app.rb
@@ -55,6 +55,17 @@ Rails.application.config.access_token_expiry = ENV.fetch('ACCESS_TOKEN_TTL', 1.h
 # log out.
 Rails.application.config.refresh_token_expiry = ENV.fetch('REFRESH_TOKEN_TTL', 1.year.to_i)
 
+# Users maintain sessions with AuthN as well. This session is secured by a lengthy secret+salt that
+# is derived from 10k iterations of PBKDF2 HMAC SHA-256. This means that any attempt to brute-force
+# the secret will have a high work factor in addition to a large search space.
+Rails.application.config.session_key = OpenSSL::PKCS5.pbkdf2_hmac(
+  require_env('SECRET_KEY_BASE'),
+  ENV.fetch('SESSION_KEY_SALT', 'session-key-salt'),
+  20_000,
+  64,
+  OpenSSL::Digest::SHA256.new
+)
+
 Rails.application.config.application_domains = require_env('APP_DOMAINS').split(',')
 
 # will be used as issuer for id tokens, and must be a URL that the application can resolve in order

--- a/config/initializers/lib.rb
+++ b/config/initializers/lib.rb
@@ -1,3 +1,4 @@
 require 'error_codes'
 require 'json_envelope'
 require 'access_control'
+require 'authn_session'

--- a/lib/authn_session.rb
+++ b/lib/authn_session.rb
@@ -1,0 +1,28 @@
+module AuthNSession
+  extend ActiveSupport::Concern
+
+  NAME = 'authn'
+
+  included do
+    include ActionController::Cookies
+  end
+
+  private def establish_session(account_id, audience)
+    # avoid any potential session fixation. whatever session they had before can't be trusted.
+    RefreshToken.revoke(authn_session[:token]) if authn_session[:token]
+
+    # NOTE: the cookie is not set to expire. the sessionjwt is not set to expire. but the refresh
+    #       token within the jwt within the cookie will expire.
+    cookies[NAME] = {
+      value: SessionJWT.generate(account_id, audience),
+      secure: Rails.application.config.force_ssl,
+      httponly: true
+    }
+
+    @authn_session = nil
+  end
+
+  private def authn_session
+    @authn_session ||= SessionJWT.decode(cookies[NAME])
+  end
+end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -18,7 +18,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       end
 
       authn_session.tap do |session|
-        assert_equal account_id, session[:sub]
+        assert_equal account_id, RefreshToken.find(session[:sub])
         assert_equal Rails.application.config.authn_url, session[:aud]
         assert_equal Rails.application.config.application_domains.first, session[:azp]
       end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -16,8 +16,12 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       assert_json_jwt(JSON.parse(response.body)['result']['id_token']) do |claims|
         assert_equal account_id, claims['sub']
       end
-      assert_equal account_id, session[:account_id]
-      assert_equal Rails.application.config.application_domains.first, session[:audience]
+
+      authn_session.tap do |session|
+        assert_equal account_id, session[:sub]
+        assert_equal Rails.application.config.authn_url, session[:aud]
+        assert_equal Rails.application.config.application_domains.first, session[:azp]
+      end
     end
 
     test 'with missing fields' do

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -63,7 +63,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
 
       authn_session.tap do |session|
-        assert_equal account.id, session[:sub]
+        assert_equal account.id, RefreshToken.find(session[:sub])
         assert_equal Rails.application.config.authn_url, session[:aud]
         assert_equal Rails.application.config.application_domains.first, session[:azp]
       end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -61,8 +61,12 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       assert_json_jwt(JSON.parse(response.body)['result']['id_token']) do |claims|
         assert_equal account.id, claims['sub']
       end
-      assert_equal account.id, session[:account_id]
-      assert_equal Rails.application.config.application_domains.first, session[:audience]
+
+      authn_session.tap do |session|
+        assert_equal account.id, session[:sub]
+        assert_equal Rails.application.config.authn_url, session[:aud]
+        assert_equal Rails.application.config.application_domains.first, session[:azp]
+      end
     end
 
     test 'with invalid token' do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -18,7 +18,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       authn_session.tap do |session|
-        assert_equal account.id, session[:sub]
+        assert_equal account.id, RefreshToken.find(session[:sub])
         assert_equal Rails.application.config.authn_url, session[:aud]
         assert_equal Rails.application.config.application_domains.first, session[:azp]
       end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -16,8 +16,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       assert_json_jwt(JSON.parse(response.body)['result']['id_token']) do |claims|
         assert_equal account.id, claims['sub']
       end
-      assert_equal account.id, session[:account_id]
-      assert_equal Rails.application.config.application_domains.first, session[:audience]
+
+      authn_session.tap do |session|
+        assert_equal account.id, session[:sub]
+        assert_equal Rails.application.config.authn_url, session[:aud]
+        assert_equal Rails.application.config.application_domains.first, session[:azp]
+      end
     end
 
     test 'with locked credentials' do

--- a/test/models/refresh_token_test.rb
+++ b/test/models/refresh_token_test.rb
@@ -5,7 +5,7 @@ class RefreshTokenTest < ActiveSupport::TestCase
     account_id = rand(9999)
 
     hex = RefreshToken.create(account_id)
-    assert_equal account_id.to_s, RefreshToken.find(hex)
+    assert_equal account_id, RefreshToken.find(hex)
     assert_equal [hex], RefreshToken.sessions(account_id)
     RefreshToken.revoke(hex)
     refute RefreshToken.find(hex)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,10 +39,10 @@ class ActiveSupport::TestCase
 
   def with_session(account_id: nil, token: nil)
     account_id ||= rand(9999)
-    ApplicationController.stub_any_instance(:session, {
-      account_id: account_id,
-      token: token || RefreshToken.create(account_id)}
-    ) do
+    ApplicationController.stub_any_instance(:authn_session, {
+      sub: account_id,
+      token: token || RefreshToken.create(account_id)
+    }) do
       yield
     end
   end
@@ -58,6 +58,10 @@ class ActiveSupport::TestCase
   end
 
   private
+
+  def authn_session
+    JSON::JWT.decode(cookies[ApplicationController::AUTHN_SESSION_NAME], Rails.application.config.session_key)
+  end
 
   def assert_json_jwt(str)
     assert str.presence

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,8 +40,7 @@ class ActiveSupport::TestCase
   def with_session(account_id: nil, token: nil)
     account_id ||= rand(9999)
     ApplicationController.stub_any_instance(:authn_session, {
-      sub: account_id,
-      token: token || RefreshToken.create(account_id)
+      sub: token || RefreshToken.create(account_id)
     }) do
       yield
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,7 +59,7 @@ class ActiveSupport::TestCase
   private
 
   def authn_session
-    JSON::JWT.decode(cookies[ApplicationController::AUTHN_SESSION_NAME], Rails.application.config.session_key)
+    JSON::JWT.decode(cookies[AuthNSession::NAME], Rails.application.config.session_key)
   end
 
   def assert_json_jwt(str)


### PR DESCRIPTION
Uses JWT for the session maintained between the user and AuthN, for better consistency. It's still an HMAC message, same as with Rails, so that threat model remains unchanged.

The derived session key, however, now uses 20k iterations of SHA-256 instead of 1k iterations of SHA-1. This only happens when starting the app, so it's an easy cost to pay.

Also, the session no longer includes an account id. We instead rely entirely on the refresh token in Redis, which means that there is no way to access and use the session once the refresh token has expired or been revoked. This will be important when the session begins to act as a third method of access control for certain endpoints like changing a password while logged in.