### PR TITLE
JWT repositories

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,15 +24,7 @@ class ApplicationController < ActionController::API
 
   private def issue_token_from(sess)
     ActivesTracker.new(sess[:sub]).perform
-
-    JSON::JWT.new(
-      iss: sess[:iss],
-      sub: RefreshToken.find(sess[:sub]),
-      aud: sess[:azp],
-      exp: Time.now.utc.to_i + Rails.application.config.access_token_expiry,
-      iat: Time.now.utc.to_i,
-      auth_time: sess[:iat]
-    ).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+    IdentityJWT.generate(sess)
   end
 
 end

--- a/app/models/identity_jwt.rb
+++ b/app/models/identity_jwt.rb
@@ -1,0 +1,12 @@
+module IdentityJWT
+  def self.generate(session)
+    JSON::JWT.new(
+      iss: session[:iss],
+      sub: RefreshToken.find(session[:sub]),
+      aud: session[:azp],
+      exp: Time.now.utc.to_i + Rails.application.config.access_token_expiry,
+      iat: Time.now.utc.to_i,
+      auth_time: session[:iat]
+    ).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+  end
+end

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -1,7 +1,7 @@
-module PasswordResetJWT
-  # TODO: switch to HMAC with another derived key
+# TODO: switch to HMAC with another derived key
+class PasswordResetJWT
   def self.generate(account_id, password_changed_at)
-    JSON::JWT.new(
+    new(
       iss: Rails.application.config.authn_url,
       sub: account_id,
       aud: Rails.application.config.authn_url,
@@ -9,12 +9,39 @@ module PasswordResetJWT
       iat: Time.now.utc.to_i,
       scope: PasswordUpdater::SCOPE,
       lock: password_changed_at.to_i
-    ).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+    ).to_s
   end
 
   def self.decode(str)
-    JSON::JWT.decode(str, Rails.application.config.auth_public_key)
+    new(JSON::JWT.decode(str, Rails.application.config.auth_public_key))
   rescue JSON::JWT::InvalidFormat
-    {}
+    new({})
+  end
+
+  def initialize(claims)
+    @claims = claims
+  end
+
+  def sub
+    @claims[:sub]
+  end
+
+  def lock
+    @claims[:lock]
+  end
+
+  def valid?
+    @claims[:iss] == Rails.application.config.authn_url &&
+      @claims[:aud] == Rails.application.config.authn_url &&
+      @claims[:scope] == PasswordUpdater::SCOPE &&
+      @claims[:exp] > Time.now.to_i
+  end
+
+  def to_s
+    JSON::JWT.new(@claims)
+      .sign(
+        Rails.application.config.auth_private_key,
+        Rails.application.config.auth_signing_alg
+      ).to_s
   end
 end

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -13,7 +13,8 @@ class PasswordResetJWT
   end
 
   def self.decode(str)
-    new(JSON::JWT.decode(str, Rails.application.config.auth_public_key))
+    return new({}) if str.blank?
+    new(JSON::JWT.decode(str, Rails.application.config.password_reset_token_key))
   rescue JSON::JWT::InvalidFormat
     new({})
   end
@@ -39,9 +40,7 @@ class PasswordResetJWT
 
   def to_s
     JSON::JWT.new(@claims)
-      .sign(
-        Rails.application.config.auth_private_key,
-        Rails.application.config.auth_signing_alg
-      ).to_s
+      .sign(Rails.application.config.password_reset_token_key, 'HS256')
+      .to_s
   end
 end

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -1,0 +1,20 @@
+module PasswordResetJWT
+  # TODO: switch to HMAC with another derived key
+  def self.generate(account_id, password_changed_at)
+    JSON::JWT.new(
+      iss: Rails.application.config.authn_url,
+      sub: account_id,
+      aud: Rails.application.config.authn_url,
+      exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
+      iat: Time.now.utc.to_i,
+      scope: PasswordUpdater::SCOPE,
+      lock: password_changed_at.to_i
+    ).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+  end
+
+  def self.decode(str)
+    JSON::JWT.decode(str, Rails.application.config.auth_public_key)
+  rescue JSON::JWT::InvalidFormat
+    {}
+  end
+end

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -1,4 +1,3 @@
-# TODO: switch to HMAC with another derived key
 class PasswordResetJWT
   def self.generate(account_id, password_changed_at)
     new(

--- a/app/models/session_jwt.rb
+++ b/app/models/session_jwt.rb
@@ -1,4 +1,4 @@
-class SessionJWT
+module SessionJWT
   def self.generate(account_id, azp)
     JSON::JWT.new(
       iss: Rails.application.config.authn_url,

--- a/app/services/password_updater.rb
+++ b/app/services/password_updater.rb
@@ -21,16 +21,12 @@ class PasswordUpdater
   end
 
   def account
-    @account ||= Account.active.find_by_id(token[:sub])
+    @account ||= Account.active.find_by_id(token.sub)
   end
 
-  # TODO: move into PasswordResetJWT instance
   private def token_is_valid_and_fresh
-    if token[:iss] != Rails.application.config.authn_url ||
-      token[:aud] != Rails.application.config.authn_url ||
-      token[:scope] != PasswordUpdater::SCOPE ||
-      token[:exp] <= Time.now.to_i ||
-      (account && token[:lock] != account.password_changed_at.to_i)
+    unless token.valid? &&
+      (account && token.lock == account.password_changed_at.to_i)
 
       errors.add(:token, ErrorCodes::INVALID_OR_EXPIRED)
     end

--- a/app/services/password_updater.rb
+++ b/app/services/password_updater.rb
@@ -11,11 +11,7 @@ class PasswordUpdater
 
   def initialize(jwt, password)
     @password = password
-    @token = begin
-      JSON::JWT.decode(jwt, Rails.application.config.auth_public_key)
-    rescue JSON::JWT::InvalidFormat
-      {}
-    end
+    @token = PasswordResetJWT.decode(jwt)
   end
 
   def perform
@@ -28,6 +24,7 @@ class PasswordUpdater
     @account ||= Account.active.find_by_id(token[:sub])
   end
 
+  # TODO: move into PasswordResetJWT instance
   private def token_is_valid_and_fresh
     if token[:iss] != Rails.application.config.authn_url ||
       token[:aud] != Rails.application.config.authn_url ||

--- a/app/services/send_reset_token_job.rb
+++ b/app/services/send_reset_token_job.rb
@@ -2,19 +2,9 @@ class SendResetTokenJob
   include SuckerPunch::Job
 
   def perform(account)
-    reset_token = JSON::JWT.new(
-      iss: Rails.application.config.authn_url,
-      sub: account.id,
-      aud: Rails.application.config.authn_url,
-      exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
-      iat: Time.now.utc.to_i,
-      scope: PasswordUpdater::SCOPE,
-      lock: account.password_changed_at.to_i
-    ).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
-
     Net::HTTP.post_form(Rails.application.config.application_endpoints[:password_reset_uri],
       account_id: account.id,
-      token: reset_token
+      token: PasswordResetJWT.generate(account.id, account.password_changed_at)
     )
   end
 end

--- a/config/initializers/app.rb
+++ b/config/initializers/app.rb
@@ -66,6 +66,14 @@ Rails.application.config.session_key = OpenSSL::PKCS5.pbkdf2_hmac(
   OpenSSL::Digest::SHA256.new
 )
 
+Rails.application.config.password_reset_token_key = OpenSSL::PKCS5.pbkdf2_hmac(
+  require_env('SECRET_KEY_BASE'),
+  ENV.fetch('PASSWORD_RESET_TOKEN_KEY_SALT', 'password-reset-token-key-salt'),
+  20_000,
+  64,
+  OpenSSL::Digest::SHA256.new
+)
+
 Rails.application.config.application_domains = require_env('APP_DOMAINS').split(',')
 
 # will be used as issuer for id tokens, and must be a URL that the application can resolve in order

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -113,7 +113,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private def jwt(account, claim_overrides = {})
-    claims = {
+    PasswordResetJWT.new({
       iss: Rails.application.config.authn_url,
       sub: account.id,
       aud: Rails.application.config.authn_url,
@@ -121,7 +121,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       iat: Time.now.utc.to_i,
       scope: PasswordUpdater::SCOPE,
       lock: account.password_changed_at.to_i
-    }.merge(claim_overrides)
-    JSON::JWT.new(claims).sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+    }.merge(claim_overrides))
+      .to_s
   end
 end

--- a/test/models/password_reset_jwt_test.rb
+++ b/test/models/password_reset_jwt_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class PasswordResetJWTTest < ActiveSupport::TestCase
+  testing '.generate' do
+    test 'returns signed JWT string' do
+      jwt = PasswordResetJWT.generate(rand(999), Time.now.to_i)
+      assert jwt.is_a?(String)
+      assert_equal 3, jwt.split('.').reject(&:blank?).count
+    end
+  end
+
+  testing '.decode' do
+    test 'returns PasswordResetJWT' do
+      account_id = rand(999)
+      time = Time.now.to_i
+
+      token = PasswordResetJWT.generate(account_id, time)
+      val = PasswordResetJWT.decode(token)
+      assert val.is_a?(PasswordResetJWT)
+      assert_equal account_id, val.sub
+      assert_equal time, val.lock
+    end
+  end
+
+  testing '#valid?' do
+    test 'with expected claims' do
+      assert jwt().valid?
+    end
+
+    test 'with unknown issuer' do
+      refute jwt(iss: 'https://unknown.tech').valid?
+    end
+
+    test 'with unknown audience' do
+      refute jwt(aud: 'https://unknown.tech').valid?
+    end
+
+    test 'with unknown scope' do
+      refute jwt(scope: 'UNKNOWN').valid?
+    end
+
+    test 'after expiration' do
+      refute jwt(exp: 1.hour.ago).valid?
+    end
+  end
+
+  def jwt(claim_overrides = {})
+    PasswordResetJWT.new({
+      iss: Rails.application.config.authn_url,
+      sub: rand(999),
+      aud: Rails.application.config.authn_url,
+      exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
+      iat: Time.now.utc.to_i,
+      scope: PasswordUpdater::SCOPE,
+      lock: Time.now.utc.to_i
+    }.merge(claim_overrides))
+  end
+end

--- a/test/services/password_updater_test.rb
+++ b/test/services/password_updater_test.rb
@@ -114,8 +114,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
   end
 
   private def jwt(account, claim_overrides = {})
-    JSON::JWT.new(claims(account, claim_overrides))
-      .sign(Rails.application.config.auth_private_key, Rails.application.config.auth_signing_alg).to_s
+    PasswordResetJWT.new(claims(account, claim_overrides)).to_s
   end
 
   private def claims(account, overrides = {})

--- a/test/services/password_updater_test.rb
+++ b/test/services/password_updater_test.rb
@@ -28,36 +28,9 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
       assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
     end
 
-    test 'with tampered token' do
+    test 'with invalid token' do
       account = FactoryGirl.create(:account)
       token = jwt(account, iss: 'https://elsewhere.tech')
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
-
-      refute updater.perform
-      assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
-    end
-
-    test 'with valid token from malicious issuer' do
-      account = FactoryGirl.create(:account)
-      token = jwt(account, iss: 'https://evil.tech')
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
-
-      refute updater.perform
-      assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
-    end
-
-    test 'with repurposed token' do
-      account = FactoryGirl.create(:account)
-      token = jwt(account, scope: 'OTHER')
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
-
-      refute updater.perform
-      assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
-    end
-
-    test 'with expired token' do
-      account = FactoryGirl.create(:account)
-      token = jwt(account, exp: 1.hour.ago)
       updater = PasswordUpdater.new(token, SecureRandom.hex(8))
 
       refute updater.perform
@@ -114,11 +87,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
   end
 
   private def jwt(account, claim_overrides = {})
-    PasswordResetJWT.new(claims(account, claim_overrides)).to_s
-  end
-
-  private def claims(account, overrides = {})
-    {
+    PasswordResetJWT.new({
       iss: Rails.application.config.authn_url,
       sub: account.id,
       aud: Rails.application.config.authn_url,
@@ -126,6 +95,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
       iat: Time.now.utc.to_i,
       scope: PasswordUpdater::SCOPE,
       lock: account.password_changed_at.to_i
-    }.merge(overrides)
+    }.merge(claim_overrides))
+      .to_s
   end
 end


### PR DESCRIPTION
This extends the repository pattern introduced in https://github.com/keratin/authn/pull/30 for both `IdentityJWT` and `PasswordResetJWT`. It's a nice improvement, but still doesn't fix the problem with tests needing some kind of `jwt` helper with its own copy of the default claims.

While doing this, I also switched the `PasswordResetJWT` signing to HMAC. This reduces the use of the public signing key to only `IdentityJWT`, which reduces timing problems with potential key rotation (https://github.com/keratin/authn/issues/23).