### PR TITLE
add support for validating email domains

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -36,6 +36,7 @@ class Account < ApplicationRecord
     def self.included(base)
       base.validates :username, presence: { message: ErrorCodes::MISSING }
       base.validate  :username_format
+      base.validate  :username_domain
     end
 
     # worried about an imperfect regex? see: http://www.regular-expressions.info/email.html
@@ -52,6 +53,15 @@ class Account < ApplicationRecord
       if Rails.application.config.email_usernames
         errors.add(:username, ErrorCodes::FORMAT_INVALID) unless username =~ EMAIL
       elsif username.length < Account::USERNAME_MIN_LENGTH
+        errors.add(:username, ErrorCodes::FORMAT_INVALID)
+      end
+    end
+
+    private def username_domain
+      return if username.blank?
+      return unless Rails.application.config.email_usernames && Rails.application.config.email_username_domains
+
+      unless username.split('@').last.in?(Rails.application.config.email_username_domains)
         errors.add(:username, ErrorCodes::FORMAT_INVALID)
       end
     end

--- a/config/initializers/app.rb
+++ b/config/initializers/app.rb
@@ -122,3 +122,5 @@ BCrypt::Engine.cost = [10, ENV.fetch('BCRYPT_COST', 11).to_i].max
 
 #
 Rails.application.config.email_usernames = ENV.fetch('USERNAME_IS_EMAIL', false).to_s =~ /^t|true|yes$/i
+
+Rails.application.config.email_username_domains = ENV['EMAIL_USERNAME_DOMAINS'].try!{|val| val.split(',') }

--- a/test/services/account_creator_test.rb
+++ b/test/services/account_creator_test.rb
@@ -46,11 +46,28 @@ class AccountCreatorTest < ActiveSupport::TestCase
       assert_equal [ErrorCodes::FORMAT_INVALID], creator.errors[:username]
     end
 
+    test 'when emails are expected' do
+      with_config(:email_usernames, true) do
+        creator = AccountCreator.new('username@somewhere.com', SecureRandom.hex(8))
+        assert creator.perform
+      end
+    end
+
     test 'with plain name when emails are expected' do
       with_config(:email_usernames, true) do
         creator = AccountCreator.new('username', SecureRandom.hex(8))
         refute creator.perform
         assert_equal [ErrorCodes::FORMAT_INVALID], creator.errors[:username]
+      end
+    end
+
+    test 'with unknown domain when emails are expected and domains checked' do
+      with_config(:email_usernames, true) do
+        with_config(:email_username_domains, ['here.com']) do
+          creator = AccountCreator.new('username@there.com', SecureRandom.hex(8))
+          refute creator.perform
+          assert_equal [ErrorCodes::FORMAT_INVALID], creator.errors[:username]
+        end
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/keratin/authn/issues/19

This adds support for restricting account creation to emails with a specific domain. Note that this is only a piece of the solution, because AuthN is not responsible for verifying email ownership. A full guide will be published in the wiki.