### PR TITLE
improvements to password resets

### DIFF
--- a/app/services/password_updater.rb
+++ b/app/services/password_updater.rb
@@ -6,7 +6,7 @@ class PasswordUpdater
   attr_reader :token, :password
 
   validate  :token_is_valid_and_fresh
-  validates :account, presence: { message: ErrorCodes::NOT_FOUND }
+  validates :account, presence: { message: ErrorCodes::NOT_FOUND }, if: ->{ token.valid? }
   validate  :account_not_locked
 
   def initialize(jwt, password)
@@ -26,7 +26,7 @@ class PasswordUpdater
 
   private def token_is_valid_and_fresh
     unless token.valid? &&
-      (account && token.lock == account.password_changed_at.to_i)
+      (!account || token.lock == account.password_changed_at.to_i)
 
       errors.add(:token, ErrorCodes::INVALID_OR_EXPIRED)
     end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,5 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource '/accounts/available', methods: [:post], headers: :any
     resource '/sessions', methods: [:post], headers: :any
     resource '/sessions/refresh', methods: [:get], headers: :any
+    resource '/password/reset', methods: [:get], headers: :any
+    resource '/password', methods: [:post], headers: :any
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,8 @@ Rails.application.routes.draw do
     get :logout, action: 'destroy'
   end
 
-  resource :password, only: [:edit, :update]
+  get '/password/reset' => 'passwords#edit'
+  post '/password' => 'passwords#update'
 
   # NOTE: this does not use .well-known/openid-configuration because this service does
   #       not fully conform to the openid-connect spec.

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -8,7 +8,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
       account = FactoryGirl.create(:account)
 
-      get edit_password_path,
+      get password_reset_path,
         params: {
           username: account.username
         },
@@ -22,7 +22,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'with unknown username' do
-      get edit_password_path,
+      get password_reset_path,
         params: {
           username: 'unknown'
         },
@@ -34,7 +34,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     test 'with locked account' do
       account = FactoryGirl.create(:account, :locked)
 
-      get edit_password_path,
+      get password_reset_path,
         params: {
           username: account.username
         },
@@ -49,7 +49,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       account = FactoryGirl.create(:account)
       password = SecureRandom.hex(8)
 
-      patch password_path,
+      post password_path,
         params: {
           token: jwt(account),
           password: password
@@ -72,7 +72,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     test 'with invalid token' do
       account = FactoryGirl.create(:account)
 
-      patch password_path,
+      post password_path,
         params: {
           token: jwt(account, scope: 'OTHER'),
           password: SecureRandom.hex(8)
@@ -86,7 +86,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     test 'with expired token' do
       account = FactoryGirl.create(:account)
 
-      patch password_path,
+      post password_path,
         params: {
           token: jwt(account, exp: 1.hour.ago),
           password: SecureRandom.hex(8)
@@ -100,7 +100,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     test 'with weak password' do
       account = FactoryGirl.create(:account)
 
-      patch password_path,
+      post password_path,
         params: {
           token: jwt(account),
           password: 'password'

--- a/test/services/password_updater_test.rb
+++ b/test/services/password_updater_test.rb
@@ -26,6 +26,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
 
       refute updater.perform
       assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
+      assert_equal [], updater.errors[:account]
     end
 
     test 'with invalid token' do


### PR DESCRIPTION
* Changes `GET /password/edit` to `GET /password/reset`. Mapping this action to "edit" makes sense from a certain viewpoint, but that requires more cognitive effort.
* Changes `PATCH /password` to `POST /password`. The `PATCH` verb would make more sense if it was against `/account`.
* Fixes extraneous "account not found" error when token is invalid (missing)
* Adds CORS configuration for password endpoints