### PR TITLE
logged-in password change

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -23,7 +23,12 @@ class PasswordsController < ApplicationController
   def update
     raise AccessForbidden unless referred?
 
-    updater = PasswordResetter.new(params[:token], params[:password])
+    if params[:token]
+      updater = PasswordResetter.new(params[:token], params[:password])
+    else
+      account_id = RefreshToken.find(authn_session[:sub])
+      updater = PasswordChanger.new(account_id, params[:password])
+    end
 
     if updater.perform
       establish_session(updater.account.id, requesting_audience)

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -23,7 +23,7 @@ class PasswordsController < ApplicationController
   def update
     raise AccessForbidden unless referred?
 
-    updater = PasswordUpdater.new(params[:token], params[:password])
+    updater = PasswordResetter.new(params[:token], params[:password])
 
     if updater.perform
       establish_session(updater.account.id, requesting_audience)

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -6,7 +6,7 @@ class PasswordResetJWT
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordUpdater::SCOPE,
+      scope: PasswordResetter::SCOPE,
       lock: password_changed_at.to_i
     ).to_s
   end
@@ -33,7 +33,7 @@ class PasswordResetJWT
   def valid?
     @claims[:iss] == Rails.application.config.authn_url &&
       @claims[:aud] == Rails.application.config.authn_url &&
-      @claims[:scope] == PasswordUpdater::SCOPE &&
+      @claims[:scope] == PasswordResetter::SCOPE &&
       @claims[:exp] > Time.now.to_i
   end
 

--- a/app/models/password_reset_jwt.rb
+++ b/app/models/password_reset_jwt.rb
@@ -1,4 +1,6 @@
 class PasswordResetJWT
+  SCOPE = 'reset'
+
   def self.generate(account_id, password_changed_at)
     new(
       iss: Rails.application.config.authn_url,
@@ -6,7 +8,7 @@ class PasswordResetJWT
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordResetter::SCOPE,
+      scope: SCOPE,
       lock: password_changed_at.to_i
     ).to_s
   end
@@ -33,7 +35,7 @@ class PasswordResetJWT
   def valid?
     @claims[:iss] == Rails.application.config.authn_url &&
       @claims[:aud] == Rails.application.config.authn_url &&
-      @claims[:scope] == PasswordResetter::SCOPE &&
+      @claims[:scope] == SCOPE &&
       @claims[:exp] > Time.now.to_i
   end
 

--- a/app/services/password_changer.rb
+++ b/app/services/password_changer.rb
@@ -1,0 +1,31 @@
+# Like PasswordResetter, but relies on a known account id (e.g. from the session)
+class PasswordChanger
+  include ActiveModel::Validations
+
+  attr_reader :account_id, :password
+
+  include Account::PasswordValidations
+  validates :account, presence: { message: ErrorCodes::NOT_FOUND }
+  validate  :account_not_locked
+
+  def initialize(account_id, password)
+    @password = password
+    @account_id = account_id
+  end
+
+  def perform
+    if valid?
+      account.update(password: BCrypt::Password.create(password).to_s)
+    end
+  end
+
+  def account
+    @account ||= Account.active.find_by_id(account_id)
+  end
+
+  private def account_not_locked
+    if account && account.locked?
+      errors.add(:account, ErrorCodes::LOCKED)
+    end
+  end
+end

--- a/app/services/password_resetter.rb
+++ b/app/services/password_resetter.rb
@@ -1,6 +1,5 @@
 # Like PasswordChanger, but decodes a reset token to find the account
 class PasswordResetter
-  SCOPE = 'reset'
   include ActiveModel::Validations
 
   attr_reader :token, :password

--- a/app/services/password_resetter.rb
+++ b/app/services/password_resetter.rb
@@ -1,13 +1,14 @@
-class PasswordUpdater
+# Like PasswordChanger, but decodes a reset token to find the account
+class PasswordResetter
   SCOPE = 'reset'
   include ActiveModel::Validations
-  include Account::PasswordValidations
 
   attr_reader :token, :password
 
-  validate  :token_is_valid_and_fresh
+  include Account::PasswordValidations
   validates :account, presence: { message: ErrorCodes::NOT_FOUND }, if: ->{ token.valid? }
   validate  :account_not_locked
+  validate  :token_is_valid_and_fresh
 
   def initialize(jwt, password)
     @password = password
@@ -24,17 +25,17 @@ class PasswordUpdater
     @account ||= Account.active.find_by_id(token.sub)
   end
 
+  private def account_not_locked
+    if account && account.locked?
+      errors.add(:account, ErrorCodes::LOCKED)
+    end
+  end
+
   private def token_is_valid_and_fresh
     unless token.valid? &&
       (!account || token.lock == account.password_changed_at.to_i)
 
       errors.add(:token, ErrorCodes::INVALID_OR_EXPIRED)
-    end
-  end
-
-  private def account_not_locked
-    if account && account.locked?
-      errors.add(:account, ErrorCodes::LOCKED)
     end
   end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -119,7 +119,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordUpdater::SCOPE,
+      scope: PasswordResetter::SCOPE,
       lock: account.password_changed_at.to_i
     }.merge(claim_overrides))
       .to_s

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -169,7 +169,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordResetter::SCOPE,
+      scope: PasswordResetJWT::SCOPE,
       lock: account.password_changed_at.to_i
     }.merge(claim_overrides))
       .to_s

--- a/test/models/password_reset_jwt_test.rb
+++ b/test/models/password_reset_jwt_test.rb
@@ -51,7 +51,7 @@ class PasswordResetJWTTest < ActiveSupport::TestCase
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordUpdater::SCOPE,
+      scope: PasswordResetter::SCOPE,
       lock: Time.now.utc.to_i
     }.merge(claim_overrides))
   end

--- a/test/models/password_reset_jwt_test.rb
+++ b/test/models/password_reset_jwt_test.rb
@@ -51,7 +51,7 @@ class PasswordResetJWTTest < ActiveSupport::TestCase
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordResetter::SCOPE,
+      scope: PasswordResetJWT::SCOPE,
       lock: Time.now.utc.to_i
     }.merge(claim_overrides))
   end

--- a/test/services/password_changer_test.rb
+++ b/test/services/password_changer_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class PasswordChangerTest < ActiveSupport::TestCase
+  def setup
+    Timecop.freeze
+    super
+  end
+
+  def teardown
+    super
+    Timecop.return
+  end
+
+  testing '#perform' do
+    test 'with account_id and password' do
+      account = FactoryGirl.create(:account)
+      updater = PasswordChanger.new(account.id, SecureRandom.hex(8))
+
+      assert updater.perform
+      assert account.reload.authenticate(updater.password)
+    end
+
+    test 'with a missing password' do
+      account = FactoryGirl.create(:account)
+      updater = PasswordChanger.new(account.id, '')
+
+      refute updater.perform
+      assert_equal [ErrorCodes::MISSING], updater.errors[:password]
+    end
+
+    test 'with a weak password' do
+      account = FactoryGirl.create(:account)
+      updater = PasswordChanger.new(account.id, 'password')
+
+      refute updater.perform
+      assert_equal [ErrorCodes::INSECURE], updater.errors[:password]
+    end
+
+    test 'with missing account_id' do
+      updater = PasswordChanger.new(nil, SecureRandom.hex(8))
+
+      refute updater.perform
+      assert_equal [ErrorCodes::NOT_FOUND], updater.errors[:account]
+    end
+
+    test 'with archived account' do
+      account = FactoryGirl.create(:account, :archived)
+      updater = PasswordChanger.new(account.id, SecureRandom.hex(8))
+
+      refute updater.perform
+      assert_equal [ErrorCodes::NOT_FOUND], updater.errors[:account]
+    end
+
+    test 'with locked account' do
+      account = FactoryGirl.create(:account, :locked)
+      updater = PasswordChanger.new(account.id, SecureRandom.hex(8))
+
+      refute updater.perform
+      assert_equal [ErrorCodes::LOCKED], updater.errors[:account]
+    end
+  end
+end

--- a/test/services/password_resetter_test.rb
+++ b/test/services/password_resetter_test.rb
@@ -94,7 +94,7 @@ class PasswordResetterTest < ActiveSupport::TestCase
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordResetter::SCOPE,
+      scope: PasswordResetJWT::SCOPE,
       lock: account.password_changed_at.to_i
     }.merge(claim_overrides))
       .to_s

--- a/test/services/password_resetter_test.rb
+++ b/test/services/password_resetter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PasswordUpdaterTest < ActiveSupport::TestCase
+class PasswordResetterTest < ActiveSupport::TestCase
   def setup
     Timecop.freeze
     super
@@ -15,14 +15,14 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with valid token and password' do
       account = FactoryGirl.create(:account)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
       assert updater.perform
       assert account.reload.authenticate(updater.password)
     end
 
     test 'with missing token' do
-      updater = PasswordUpdater.new('', SecureRandom.hex(8))
+      updater = PasswordResetter.new('', SecureRandom.hex(8))
 
       refute updater.perform
       assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
@@ -32,7 +32,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with invalid token' do
       account = FactoryGirl.create(:account)
       token = jwt(account, iss: 'https://elsewhere.tech')
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
       refute updater.perform
       assert_equal [ErrorCodes::INVALID_OR_EXPIRED], updater.errors[:token]
@@ -41,7 +41,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'when password has been changed since issuing token' do
       account = FactoryGirl.create(:account)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
       Timecop.travel(1)
       assert updater.perform
@@ -53,7 +53,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with a missing password' do
       account = FactoryGirl.create(:account)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, '')
+      updater = PasswordResetter.new(token, '')
 
       refute updater.perform
       assert_equal [ErrorCodes::MISSING], updater.errors[:password]
@@ -62,7 +62,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with a weak password' do
       account = FactoryGirl.create(:account)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, 'password')
+      updater = PasswordResetter.new(token, 'password')
 
       refute updater.perform
       assert_equal [ErrorCodes::INSECURE], updater.errors[:password]
@@ -71,7 +71,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with archived account' do
       account = FactoryGirl.create(:account, :archived)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
       refute updater.perform
       assert_equal [ErrorCodes::NOT_FOUND], updater.errors[:account]
@@ -80,7 +80,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
     test 'with locked account' do
       account = FactoryGirl.create(:account, :locked)
       token = jwt(account)
-      updater = PasswordUpdater.new(token, SecureRandom.hex(8))
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
       refute updater.perform
       assert_equal [ErrorCodes::LOCKED], updater.errors[:account]
@@ -94,7 +94,7 @@ class PasswordUpdaterTest < ActiveSupport::TestCase
       aud: Rails.application.config.authn_url,
       exp: Time.now.utc.to_i + Rails.application.config.password_reset_expiry,
       iat: Time.now.utc.to_i,
-      scope: PasswordUpdater::SCOPE,
+      scope: PasswordResetter::SCOPE,
       lock: account.password_changed_at.to_i
     }.merge(claim_overrides))
       .to_s


### PR DESCRIPTION
If a device has an active session with AuthN, we can use that to identify the account and authorize a password change. This is simpler than password resets.

Note that if a reset token is offered, it must be preferred. This is for scenarios where someone opens a reset email on a device that is actually logged in to a family member's account (yes, it happens).

Also note that once the password is changed, the user will be logged in with that account.

There's plenty of duplication between the new `PasswordChanger` and the rebranded `PasswordResetter`. I haven't decided how to resolve it.