### PR TITLE
simplify RSA key management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ db/*.sqlite3-journal
 log/*
 tmp/*
 Dockerfile
+.env
+.byebug_history

--- a/app.json
+++ b/app.json
@@ -19,9 +19,6 @@
     "RSA_PRIVATE_KEY": {
       "description": "Run `ssh-keygen -N '' -f keratin-authn-rsa`, then paste the entire output of `cat keratin-authn-rsa` here."
     },
-    "RSA_PUBLIC_KEY": {
-      "description": "After running the ssh-keygen command above, paste the entire output of `ssh-keygen -e -m pem -f keratin-authn-rsa` here"
-    },
     "SECRET_KEY_BASE": {
       "description": "Key used to securely sign AuthN session cookies",
       "generator": "secret"

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -19,7 +19,7 @@ class MetadataController < ApplicationController
   def keys
     render status: :ok, json: {
       keys: [
-        Rails.application.config.auth_public_key.to_jwk.slice(:kty, :kid, :e, :n).merge(
+        Rails.application.config.auth_private_key.public_key.to_jwk.slice(:kty, :kid, :e, :n).merge(
           use: 'sig',
           alg: Rails.application.config.auth_signing_alg
         )

--- a/config/initializers/app.rb
+++ b/config/initializers/app.rb
@@ -10,15 +10,11 @@ end
 
 # currently only supports RSA 256
 if Rails.env.test?
-  keypair = OpenSSL::PKey::RSA.new(512)
-  private_key = keypair.to_s
-  public_key = keypair.public_key.to_s
+  rsa = OpenSSL::PKey::RSA.new(512)
 else
-  private_key = require_env('RSA_PRIVATE_KEY').gsub('\n', "\n")
-  public_key = require_env('RSA_PUBLIC_KEY').gsub('\n', "\n")
+  rsa = OpenSSL::PKey::RSA.new(require_env('RSA_PRIVATE_KEY').gsub('\n', "\n"))
 end
-Rails.application.config.auth_private_key = OpenSSL::PKey::RSA.new(private_key)
-Rails.application.config.auth_public_key = OpenSSL::PKey::RSA.new(public_key)
+Rails.application.config.auth_private_key = rsa
 Rails.application.config.auth_signing_alg = 'RS256'
 
 # This setting controls how long the access tokens will live. Applications can and should implement

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - HTTP_AUTH_USERNAME
       - REDIS_URL=redis://redis/0
       - RSA_PRIVATE_KEY
-      - RSA_PUBLIC_KEY
       - SECRET_KEY_BASE
 
   test-base:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,7 @@ class ActiveSupport::TestCase
 
   def assert_json_jwt(str)
     assert str.presence
-    claims = JSON::JWT.decode(str, Rails.application.config.auth_public_key)
+    claims = JSON::JWT.decode(str, Rails.application.config.auth_private_key.public_key)
     yield claims
   end
 


### PR DESCRIPTION
Asking for the public key is redundant.