### PR TITLE
Missed rotation intervals

### DIFF
--- a/test/services/password_resetter_test.rb
+++ b/test/services/password_resetter_test.rb
@@ -43,7 +43,7 @@ class PasswordResetterTest < ActiveSupport::TestCase
       token = jwt(account)
       updater = PasswordResetter.new(token, SecureRandom.hex(8))
 
-      Timecop.travel(1)
+      Timecop.freeze(1)
       assert updater.perform
 
       refute updater.perform


### PR DESCRIPTION
Solves for a number of possible inconsistencies with the JWKs endpoint:

1. If an AuthN server restarts, it should still serve the current keys from its JWKs endpoint.
2. If multiple AuthN processes are running, a key may be generated by one process but should still be returned from the JWKs endpoint by other processes.
3. If an AuthN server is not consistently active, it may not generate keys during some interval. It should still remove expired keys from its JWKs endpoint.

This means performing Redis calls when fetching current keys. We still attempt memoization and trimming as appropriate to minimize traffic.