### PR TITLE
Import Account

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,6 +19,25 @@ class AccountsController < ApplicationController
   end
 
   # params:
+  # * username: string
+  # * password: string
+  # * locked: boolean
+  # * password_changed_at: unix timestamp
+  def import
+    raise AccessForbidden unless authenticated?
+
+    importer = AccountImporter.new(params.permit('username', 'password', 'locked').to_h.symbolize_keys)
+
+    if (account = importer.perform)
+      render status: :created, json: JSONEnvelope.result(
+        id: account.id
+      )
+    else
+      render status: :unprocessable_entity, json: JSONEnvelope.errors(importer.errors)
+    end
+  end
+
+  # params:
   # * username
   def available
     if Account.named(params[:username]).exists?

--- a/app/services/account_importer.rb
+++ b/app/services/account_importer.rb
@@ -1,0 +1,41 @@
+class AccountImporter
+  include ActiveModel::Validations
+  validates :username, presence: {message: ErrorCodes::MISSING}
+  validates :password, presence: {message: ErrorCodes::MISSING}
+
+  attr_reader :username
+  attr_reader :password
+  attr_reader :locked
+
+  def initialize(username: nil, password: nil, locked: false)
+    @username = username
+    @password = password
+    @locked = locked
+  end
+
+  # either returns an account or registers errors
+  def perform
+    if valid?
+      begin
+        account = Account.create(
+          username: username,
+          password: crypted_password,
+          locked: locked
+        )
+      rescue ActiveRecord::RecordNotUnique
+        # forgiveness is faster than permission
+        errors.add(:username, ErrorCodes::TAKEN)
+      end
+    end
+
+    account unless errors.any?
+  end
+
+  private def crypted_password
+    @crypted_password ||= bcrypt?(password) ? password : BCrypt::Password.create(password).to_s
+  end
+
+  private def bcrypt?(str)
+    !!str.match(/\A\$2[ayb]\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}\z/)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'metadata#stats'
 
   resources :accounts, only: [:create, :destroy] do
+    post :import, on: :collection
     get :available, on: :collection
     member do
       match :lock, via: [:put, :patch]

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@ title: Server API
     * [Lock Account](#lock-account)
     * [Unlock Account](#unlock-account)
     * [Archive Account](#archive-account)
+    * [Import Account](#import-account)
   * Sessions
     * [Login](#login)
     * [Refresh Session](#refresh-session)
@@ -199,6 +200,39 @@ Visibility: Private
     {
       "errors": [
         {"field": "account", "message": "NOT_FOUND"}
+      ]
+    }
+
+### Import Account
+
+Visibility: Private
+
+`POST /accounts/import`
+
+| Params | Type | Notes |
+| ------ | ---- | ----- |
+| `username` | string | Must exist and be unique, but otherwise not validated. |
+| `password` | string | May be either an existing BCrypt hash or a plaintext (raw) string. Will not be validated for complexity. |
+| `locked` | boolean | Optional. Will import the account as [locked](#lock-account). |
+
+#### Success:
+
+    201 Created
+
+    {
+      "result": {
+        "id": 123456789
+      }
+    }
+
+#### Failure:
+
+    422 Unprocessable Entity
+
+    {
+      "errors": [
+        {"field": "username", "message": "MISSING"},
+        {"field": "password", "message": "MISSING"}
       ]
     }
 

--- a/docs/guide-migrating_an_existing_application.md
+++ b/docs/guide-migrating_an_existing_application.md
@@ -41,13 +41,13 @@ During this period, you should expect that some users will attempt to sign up wh
 
 Now that every new user has an AuthN account, it's time to start transitioning your existing user accounts.
 
-If your legacy system uses BCrypt passwords, this is easy. You can begin looping through existing accounts, sending them to AuthN, and storing the account_id that you get back.
+If your legacy system uses BCrypt passwords, this is easy. You can begin looping through existing accounts, [sending them to AuthN](api.md#import-account), and storing the account_id that you get back.
 
 However, if your legacy system does not use BCrypt passwords you have a choice:
 
 A. Submit an [issue](https://github.com/keratin/authn) describing your situation. AuthN may be able to add support for your style of password hashing. It's important to realize that these old passwords may not be as secure, though, and after some period of time (months) you should revoke them (any active users who have logged in meanwhile will have their passwords upgraded to BCrypt seamlessly).
 
-B. Over some long period of time (1-2 months), wait for users to log in and import them to AuthN while you have their raw password available. This allows your most active users to transition seamlessly. Then, once you're satisfied with the number of users that have migrated, import the remaining accounts _without passwords_ and flagged for an immediate password change. The next time these inactive accounts return, they will see a prompt telling them to reset their password by the usual process.
+B. Over some long period of time (1-2 months), wait for users to log in and [import them to AuthN](api.md#import-account) while you have their raw password available. This allows your most active users to transition seamlessly. Then, once you're satisfied with the number of users that have migrated, import the remaining accounts _without passwords_ and flagged for an immediate password change. The next time these inactive accounts return, they will see a prompt telling them to reset their password by the usual process.
 
 ## 4. Removing Legacy System
 

--- a/test/services/account_importer_test.rb
+++ b/test/services/account_importer_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+class AccountImporterTest < ActiveSupport::TestCase
+  def setup
+    @args = {
+      username: 'username@domain.tld',
+      password: BCrypt::Password.create('hello world').to_s,
+      locked: false
+    }
+    super
+  end
+
+  testing '#perform' do
+    test 'success' do
+      importer = AccountImporter.new(@args)
+      account = importer.perform
+      assert account.persisted?
+    end
+
+    test 'with missing username' do
+      importer = AccountImporter.new(@args.merge(username: ''))
+      refute importer.perform
+      assert_equal [ErrorCodes::MISSING], importer.errors[:username]
+    end
+
+    test 'with duplicate username' do
+      account = FactoryGirl.create(:account)
+      importer = AccountImporter.new(@args.merge(username: account.username))
+      refute importer.perform
+      assert_equal [ErrorCodes::TAKEN], importer.errors[:username]
+    end
+
+    test 'with locked username' do
+      account = FactoryGirl.create(:account, :locked)
+      importer = AccountImporter.new(@args.merge(username: account.username))
+      refute importer.perform
+      assert_equal [ErrorCodes::TAKEN], importer.errors[:username]
+    end
+
+    test 'with plain name when emails are expected' do
+      with_config(:email_usernames, true) do
+        importer = AccountImporter.new(@args.merge(username: 'username'))
+        assert importer.perform
+      end
+    end
+
+    test 'with missing password' do
+      importer = AccountImporter.new(@args.merge(password: ''))
+      refute importer.perform
+      assert_equal [ErrorCodes::MISSING], importer.errors[:password]
+    end
+
+    test 'with plaintext password' do
+      importer = AccountImporter.new(@args.merge(password: 'plaintext'))
+      account = importer.perform
+      assert account.persisted?
+      assert BCrypt::Password.new(account.password).is_password?('plaintext')
+    end
+
+    test 'with locked user' do
+      importer = AccountImporter.new(@args.merge(locked: true))
+      account = importer.perform
+      assert account.persisted?
+      assert account.locked?
+    end
+
+    test 'default value for locked arg' do
+      importer = AccountImporter.new(@args.without(:locked))
+      account = importer.perform
+      refute account.locked?
+    end
+  end
+end


### PR DESCRIPTION
Adds a private (aka back-channel) endpoint to import an account directly into AuthN. This endpoint will accept both plaintext and BCrypt passwords, and will allow an account to be imported as locked.

The general use case for this endpoint is migrating an existing application, per the docs (updated). Bulk import is not supported, since the extra complexity (on both sending and processing the data) is not worth reducing the time of an unattended process. If someone wants more throughput, my recommendation is parallelization.