### PR TITLE
Forced password change

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,6 +20,8 @@ class SessionsController < ApplicationController
     if BCrypt::Password.new(account.try(&:password) || placeholder).is_password?(params[:password]) && params[:password].present?
       if account.locked?
         render status: :unprocessable_entity, json: JSONEnvelope.errors('account' => ErrorCodes::LOCKED)
+      elsif account.require_new_password?
+        render status: :unprocessable_entity, json: JSONEnvelope.errors('credentials' => ErrorCodes::EXPIRED)
       else
         establish_session(account.id, requesting_audience)
         render status: :created, json: JSONEnvelope.result(

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,6 +28,19 @@ class Account < ApplicationRecord
     @sessions ||= RefreshToken.sessions(id)
   end
 
+  # TODO: remove in next release
+  def self.migrated?
+    column_names.include?('require_new_password')
+  end
+
+  def require_new_password?
+    read_attribute(:require_new_password) if self.class.migrated?
+  end
+
+  def require_new_password=(val)
+    write_attribute(:require_new_password, val) if self.class.migrated?
+  end
+
   private def set_password_changed_at
     self.password_changed_at = Time.now if password_changed?
   end

--- a/app/services/password_changer.rb
+++ b/app/services/password_changer.rb
@@ -15,7 +15,10 @@ class PasswordChanger
 
   def perform
     return unless valid?
-    account.update(password: BCrypt::Password.create(password).to_s)
+    account.update(
+      password: BCrypt::Password.create(password).to_s,
+      require_new_password: false
+    )
   end
 
   def account

--- a/app/services/password_expirer.rb
+++ b/app/services/password_expirer.rb
@@ -1,0 +1,12 @@
+PasswordExpirer = Struct.new(:id)
+class PasswordExpirer
+  def perform
+    if (account = Account.find_by_id(id))
+      account.update(require_new_password: true)
+      account.sessions.each{|hex| RefreshToken.revoke(hex) }
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/services/password_resetter.rb
+++ b/app/services/password_resetter.rb
@@ -16,7 +16,10 @@ class PasswordResetter
 
   def perform
     return unless valid?
-    account.update(password: BCrypt::Password.create(password).to_s)
+    account.update(
+      password: BCrypt::Password.create(password).to_s,
+      require_new_password: false
+    )
   end
 
   def account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       delete :destroy
       match :lock, via: [:put, :patch]
       match :unlock, via: [:put, :patch]
+      match :expire_password, via: [:put, :patch]
     end
   end
 

--- a/db/migrate/20170316182634_add_require_new_password_to_accounts.rb
+++ b/db/migrate/20170316182634_add_require_new_password_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddRequireNewPasswordToAccounts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :accounts, :require_new_password, :boolean, default: false, null: false, after: :locked
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161101202742) do
+ActiveRecord::Schema.define(version: 20170316182634) do
 
   create_table "accounts", force: :cascade do |t|
     t.string   "username"
     t.string   "password"
-    t.boolean  "locked",              default: false, null: false
+    t.boolean  "locked",               default: false, null: false
     t.datetime "password_changed_at"
     t.datetime "deleted_at"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.boolean  "require_new_password", default: false, null: false
     t.index ["username"], name: "index_accounts_on_username", unique: true
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -264,11 +264,14 @@ Visibility: Public
     {
       "errors": [
         {"field": "credentials", "message": "FAILED"},
+        {"field": "credentials", "message": "EXPIRED"},
         {"field": "account", "message": "LOCKED"}
       ]
     }
 
 Note that no information is given to tell the user whether the username was found or the password was incorrect.
+
+When handling the `EXPIRED` error for credentials, instruct the user their password must be reset.
 
 ### Refresh Session
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@ title: Server API
   * Passwords
     * [Request Password Reset](#request-password-reset)
     * [Change Password](#change-password)
+    * [Expire Password](#expire-password)
   * Other
     * [Service Configuration](#service-configuration)
     * [JSON Web Keys](#json-web-keys)
@@ -378,6 +379,32 @@ Visibility: Public
     }
 
 Note that `NOT_FOUND` may happen if the account is archived after sending a reset token.
+
+### Expire Password
+
+Visibility: Private
+
+`PATCH|PUT /accounts/:id/expire_password`
+
+| Params | Type | Notes |
+| ------ | ---- | ----- |
+| `id` | integer | available from the JWT `sub` claim |
+
+Revokes all of the user's current sessions and flags the account for a required password change on their next login. This will manifest as an expired credentials error on what would normally have been a successful login.
+
+#### Success:
+
+    200 Ok
+
+#### Failure:
+
+    404 Not Found
+
+    {
+      "errors": [
+        {"field": "account", "message": "NOT_FOUND"}
+      ]
+    }
 
 ### Service Configuration
 

--- a/lib/error_codes.rb
+++ b/lib/error_codes.rb
@@ -7,4 +7,5 @@ module ErrorCodes
   MISSING = 'MISSING'
   NOT_FOUND = 'NOT_FOUND'
   TAKEN = 'TAKEN'
+  EXPIRED = 'EXPIRED'
 end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -184,6 +184,28 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  testing '#expire_password' do
+    test 'on active account' do
+      account = FactoryGirl.create(:account)
+
+      patch expire_password_account_path(account.id),
+        headers: API_CREDENTIALS
+
+      assert_response :ok
+      assert account.reload.require_new_password?
+    end
+
+    test 'on unknown account' do
+      patch expire_password_account_path(0),
+        headers: API_CREDENTIALS
+
+      assert_response :not_found
+      assert_json_errors(
+        'account' => ErrorCodes::NOT_FOUND
+      )
+    end
+  end
+
   testing '#destroy' do
     test 'with known account' do
       account = FactoryGirl.create(:account)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -50,6 +50,20 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       assert_json_errors('account' => ErrorCodes::LOCKED)
     end
 
+    test 'with inactive password' do
+      account = FactoryGirl.create(:account, clear_password: 'valid', require_new_password: true)
+
+      post sessions_path,
+        params: {
+          username: account.username,
+          password: 'valid'
+        },
+        headers: TRUSTED_REFERRER
+
+      assert_response(:unprocessable_entity)
+      assert_json_errors('credentials' => ErrorCodes::EXPIRED)
+    end
+
     test 'with unknown account username' do
       post sessions_path,
         params: {

--- a/test/factories/accounts.rb
+++ b/test/factories/accounts.rb
@@ -19,5 +19,9 @@ FactoryGirl.define do
     trait :locked do
       locked true
     end
+
+    trait :expired_password do
+      require_new_password true
+    end
   end
 end

--- a/test/services/password_changer_test.rb
+++ b/test/services/password_changer_test.rb
@@ -58,5 +58,13 @@ class PasswordChangerTest < ActiveSupport::TestCase
       refute updater.perform
       assert_equal [ErrorCodes::LOCKED], updater.errors[:account]
     end
+
+    test 'with expired password' do
+      account = FactoryGirl.create(:account, :expired_password)
+      updater = PasswordChanger.new(account.id, SecureRandom.hex(8))
+
+      assert updater.perform
+      refute account.reload.require_new_password?
+    end
   end
 end

--- a/test/services/password_expirer_test.rb
+++ b/test/services/password_expirer_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class PasswordExpirerTest < ActiveSupport::TestCase
+  testing '#perform' do
+    test 'success' do
+      account = FactoryGirl.create(:account)
+
+      assert PasswordExpirer.new(account.id).perform
+      assert account.reload.require_new_password?
+    end
+
+    test 'with unknown account' do
+      refute PasswordExpirer.new(0).perform
+    end
+
+    test 'with active sessions' do
+      account = FactoryGirl.create(:account)
+      hex = RefreshToken.create(account.id)
+
+      assert RefreshToken.find(hex)
+      PasswordExpirer.new(account.id).perform
+      refute RefreshToken.find(hex)
+    end
+  end
+end

--- a/test/services/password_resetter_test.rb
+++ b/test/services/password_resetter_test.rb
@@ -85,6 +85,15 @@ class PasswordResetterTest < ActiveSupport::TestCase
       refute updater.perform
       assert_equal [ErrorCodes::LOCKED], updater.errors[:account]
     end
+
+    test 'with expired password' do
+      account = FactoryGirl.create(:account, :expired_password)
+      token = jwt(account)
+      updater = PasswordResetter.new(token, SecureRandom.hex(8))
+
+      assert updater.perform
+      refute account.reload.require_new_password?
+    end
   end
 
   private def jwt(account, claim_overrides = {})


### PR DESCRIPTION
Accounts may sometimes need a forced password change. This could happen if the host app has cause to believe the account has been compromised, or shares credentials leaked in some other company's data breach. This could also be useful when importing legacy accounts with unsupported password formats into AuthN.

In those cases, the password may be "expired". This will revoke any current sessions (note that access tokens will continue to run out their lifetime), and begin _failing successful logins_ until the password has been changed.

## Upgrading

This change requires a new database field. Current deployments of AuthN are expected to be able to run `bin/rails db:migrate` (possibly with `docker exec` or `heroku run`). The feature will be stubbed out until the migration has run _and the processes have restarted_. This stub should be removed in a following release.

fixes #15 