### PR TITLE
improved support for mounted paths

### DIFF
--- a/config/initializers/app.rb
+++ b/config/initializers/app.rb
@@ -77,6 +77,7 @@ Rails.application.config.application_domains = require_env('APP_DOMAINS').split(
 #
 # e.g. https://auth.service
 Rails.application.config.authn_url = require_env('AUTHN_URL')
+Rails.application.config.mounted_path = URI.parse(Rails.application.config.authn_url).path.presence || '/'
 
 # minimum complexity score from the zxcvbn algorithm, where:
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,32 +1,34 @@
 Rails.application.routes.draw do
-  root 'metadata#stats'
+  scope Rails.application.config.mounted_path do
+    root 'metadata#stats'
 
-  resources :accounts, only: [] do
-    collection do
-      post :import
-      post :create if Rails.application.config.features[:signup]
-      get :available if Rails.application.config.features[:signup]
+    resources :accounts, only: [] do
+      collection do
+        post :import
+        post :create if Rails.application.config.features[:signup]
+        get :available if Rails.application.config.features[:signup]
+      end
+      member do
+        delete :destroy
+        match :lock, via: [:put, :patch]
+        match :unlock, via: [:put, :patch]
+        match :expire_password, via: [:put, :patch]
+      end
     end
-    member do
-      delete :destroy
-      match :lock, via: [:put, :patch]
-      match :unlock, via: [:put, :patch]
-      match :expire_password, via: [:put, :patch]
+
+    resource :sessions, only: [:create] do
+      get :refresh
+      get :logout, action: 'destroy'
     end
+
+    get '/password/reset' => 'passwords#edit'
+    post '/password' => 'passwords#update'
+
+    # NOTE: this does not use .well-known/openid-configuration because this service does
+    #       not fully conform to the openid-connect spec.
+    get '/configuration' => 'metadata#configuration', as: 'app_configuration'
+    get '/jwks' => 'metadata#keys', as: 'app_keys'
+
+    get '/stats' => 'metadata#stats', as: 'app_stats'
   end
-
-  resource :sessions, only: [:create] do
-    get :refresh
-    get :logout, action: 'destroy'
-  end
-
-  get '/password/reset' => 'passwords#edit'
-  post '/password' => 'passwords#update'
-
-  # NOTE: this does not use .well-known/openid-configuration because this service does
-  #       not fully conform to the openid-connect spec.
-  get '/configuration' => 'metadata#configuration', as: 'app_configuration'
-  get '/jwks' => 'metadata#keys', as: 'app_keys'
-
-  get '/stats' => 'metadata#stats', as: 'app_stats'
 end

--- a/lib/authn_session.rb
+++ b/lib/authn_session.rb
@@ -15,6 +15,7 @@ module AuthNSession
     #       token within the jwt within the cookie will expire.
     cookies[NAME] = {
       value: SessionJWT.generate(account_id, audience),
+      path: Rails.application.config.mounted_path,
       secure: Rails.application.config.force_ssl,
       httponly: true
     }


### PR DESCRIPTION
When the AUTHN_URL specifies a path, we need to adjust routing accordingly and also scope our cookie path to properly share the domain. Many other things already work properly: JWT issuers and audiences specify the full `AUTHN_URL` and will be properly scoped.

Fixes #43