### PR TITLE
remove http redirect logic from session destroy (updates session routes)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,24 +46,12 @@ class SessionsController < ApplicationController
     end
   end
 
-  # params:
-  # * redirect_uri (optional)
   def destroy
     raise AccessForbidden unless referred?
 
     RefreshToken.revoke(authn_session[:sub])
     cookies.delete(AuthNSession::NAME)
 
-    redirect_host = begin
-      URI.parse(params[:redirect_uri]).host
-    rescue URI::InvalidURIError
-      nil
-    end
-
-    if Rails.application.config.application_domains.include?(redirect_host)
-      redirect_to params[:redirect_uri]
-    else
-      redirect_to request.referer
-    end
+    head :ok
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,9 +16,8 @@ Rails.application.routes.draw do
       end
     end
 
-    resource :sessions, only: [:create] do
+    resource :session, only: [:create, :destroy] do
       get :refresh
-      get :logout, action: 'destroy'
     end
 
     get '/password/reset' => 'passwords#edit'

--- a/docs/api.md
+++ b/docs/api.md
@@ -241,7 +241,7 @@ Visibility: Private
 
 Visibility: Public
 
-`POST /sessions`
+`POST /session`
 
 | Params | Type | Notes |
 | ------ | ---- | ----- |
@@ -278,7 +278,7 @@ When handling the `EXPIRED` error for credentials, instruct the user their passw
 
 Visibility: Public
 
-`GET /sessions/refresh`
+`GET /session/refresh`
 
 As long as a device remains logged in to the AuthN server, it can hit this endpoint to fetch a fresh JWT session. The [`keratin/authn-js`](https://github.com/keratin/authn-js) library can automate this by pre-emptively refreshing tokens when they reach halflife.
 
@@ -302,19 +302,13 @@ This refresh scheme is necessary so that device sessions may be permanently and 
 
 Visibility: Public
 
-`GET /sessions/logout`
+`DELETE /session`
 
-When a user signs up or logs in, their device establishes a session with the AuthN service. This endpoint will revoke the AuthN session. Note that this is implemented as a redirect process, but you may also initiate the logout via XHR and manage redirects yourself as the [`keratin/authn-js`](https://github.com/keratin/authn-js) library does.
+When a user signs up or logs in, their device establishes a session with the AuthN service, and within that session is a refresh token. This endpoint will revoke the token and discard the session.
 
 #### Success:
 
-    302 Found
-    Location: ...
-
-#### Failure:
-
-    302 Found
-    Location: ...
+    200 OK
 
 ### Request Password Reset
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -5,7 +5,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     test 'with valid credentials' do
       account = FactoryGirl.create(:account, clear_password: 'valid')
 
-      post sessions_path,
+      post session_path,
         params: {
           username: account.username,
           password: 'valid'
@@ -25,7 +25,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'with empty credentials' do
-      post sessions_path,
+      post session_path,
         params: {
           username: '',
           password: ''
@@ -39,7 +39,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     test 'with locked credentials' do
       account = FactoryGirl.create(:account, :locked, clear_password: 'valid')
 
-      post sessions_path,
+      post session_path,
         params: {
           username: account.username,
           password: 'valid'
@@ -53,7 +53,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     test 'with inactive password' do
       account = FactoryGirl.create(:account, clear_password: 'valid', require_new_password: true)
 
-      post sessions_path,
+      post session_path,
         params: {
           username: account.username,
           password: 'valid'
@@ -65,7 +65,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'with unknown account username' do
-      post sessions_path,
+      post session_path,
         params: {
           username: 'unknown',
           password: 'valid'
@@ -79,7 +79,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     test 'with bad password' do
       account = FactoryGirl.create(:account, clear_password: 'valid')
 
-      post sessions_path,
+      post session_path,
         params: {
           username: account.username,
           password: 'unknown'
@@ -93,7 +93,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     test 'with untrusted referer' do
       account = FactoryGirl.create(:account, clear_password: 'valid')
 
-      post sessions_path,
+      post session_path,
         params: {
           username: account.username,
           password: 'valid'
@@ -108,7 +108,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   testing '#refresh' do
     test 'with existing valid session' do
       with_session(account_id: 42) do
-        get refresh_sessions_path,
+        get refresh_session_path,
           headers: TRUSTED_REFERRER
       end
 
@@ -119,14 +119,14 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'without existing valid session' do
-      get refresh_sessions_path,
+      get refresh_session_path,
         headers: TRUSTED_REFERRER
 
       assert_response(:unauthorized)
     end
 
     test 'with mangled session cookie' do
-      get refresh_sessions_path,
+      get refresh_session_path,
         headers: TRUSTED_REFERRER.merge(
           'Cookie' => "#{AuthNSession::NAME}=\"invalid\""
         )
@@ -135,7 +135,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'with JWT-ish session cookie' do
-      get refresh_sessions_path,
+      get refresh_session_path,
         headers: TRUSTED_REFERRER.merge(
           'Cookie' => "#{AuthNSession::NAME}=\"e30=.e30=.abc\""
         )
@@ -145,40 +145,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   testing '#destroy' do
-    test 'with valid session and safe redirect' do
+    test 'with valid session' do
       account_id = rand(9999)
       token = RefreshToken.create(account_id)
 
       with_session(account_id: account_id, token: token) do
-        get logout_sessions_path,
-          params: {
-            redirect_uri: "https://#{Rails.application.config.application_domains.first}/callback?hello=world"
-          },
+        delete session_path,
           headers: TRUSTED_REFERRER
       end
 
-      assert_response(:redirect)
-      assert_redirected_to("https://#{Rails.application.config.application_domains.first}/callback?hello=world")
+      assert_response(:ok)
       refute RefreshToken.find(token)
-    end
-
-    test 'with unknown redirect' do
-      get logout_sessions_path,
-        params: {
-          redirect_uri: 'https://evil.tech/callback'
-        },
-        headers: TRUSTED_REFERRER
-
-      assert_response(:redirect)
-      assert_redirected_to("https://#{Rails.application.config.application_domains.first}")
-    end
-
-    test 'with no redirect' do
-      get logout_sessions_path,
-        headers: TRUSTED_REFERRER
-
-      assert_response(:redirect)
-      assert_redirected_to("https://#{Rails.application.config.application_domains.first}")
     end
   end
 end


### PR DESCRIPTION
In an early prototype of AuthN, I was anticipating more HTTP redirection logic and built `SessionsController#destroy` accordingly. But AuthN is currently doing well as a pure JavaScript API, and when XmlHttpRequests automatically follow the redirect, unnecessary things happen.

This cleans up a bit. The first step was removing the redirect logic in the controller. The second step was recognizing that this route was a `GET` only for redirect purposes and should now be a `DELETE`. The third step was deciding that since the API contract is changing, I may as well properly singularize the `/session` resource.

fixes #45 